### PR TITLE
illustrate unintended behaviors on Android 12

### DIFF
--- a/PictureInPictureKotlin/app/src/main/java/com/example/android/pictureinpicture/MovieActivity.kt
+++ b/PictureInPictureKotlin/app/src/main/java/com/example/android/pictureinpicture/MovieActivity.kt
@@ -20,7 +20,10 @@ import android.app.PictureInPictureParams
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Rect
+import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
@@ -116,6 +119,21 @@ class MovieActivity : AppCompatActivity() {
     override fun onStart() {
         super.onStart()
         initializeMediaSession()
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            bug1_startActivityBeforeEnteringPiPMode()
+//            bug2_startActivityAfterEnteringPiPMode()
+        }, 5000)
+    }
+
+    private fun bug1_startActivityBeforeEnteringPiPMode() {
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://google.com")).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        enterPictureInPictureMode(updatePictureInPictureParams())
+    }
+
+    private fun bug2_startActivityAfterEnteringPiPMode() {
+        enterPictureInPictureMode(updatePictureInPictureParams())
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://google.com")))
     }
 
     private fun initializeMediaSession() {


### PR DESCRIPTION
Shows two related but different bugs when initiating PiP mode on Android 12. Tested with Pixel 5 and Pixel 4.

## Bug 1
### Steps to reproduce
`bug1_startActivityBeforeEnteringPiPMode()`

1. press button to start video activity
2. swap to lansdcape
3. wait 5 seconds
4. an activity will be started to open google.com, PiP mode will be triggered
5. rotate back to portrait
6. navigate back to the home activity
7. PiP frame will be visible but all black, the lower half of the device will be unresponsive to touch events

## Bug 2
### Steps to reproduce
use `bug2_startActivityAfterEnteringPiPMode()`

1. press button to start video activity
2. swap to lansdcape
3. wait 5 seconds
4. an activity will be started to open google.com, PiP mode will be triggered
5. PiP frame will be visible small and only take up a fraction of the total PiP frame